### PR TITLE
Remove Simd library in master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,7 +217,6 @@ dinput8-Release/
 LanguageBarrier/contrib/bin/
 LanguageBarrier/contrib/include/*.h
 LanguageBarrier/contrib/include/*.hpp
-LanguageBarrier/contrib/include/Simd/
 LanguageBarrier/lib/Debug/
 LanguageBarrier/lib/Release/
 # keep xy-VSFilter build / csri headers

--- a/LanguageBarrier/LanguageBarrier.cpp
+++ b/LanguageBarrier/LanguageBarrier.cpp
@@ -9,6 +9,9 @@
 static bool isInitialised = false;
 
 namespace lb {
+size_t alignCeil(size_t val, size_t align) {
+  return (val % align == 0) ? val : val + align - (val % align);
+}
 void LanguageBarrierInit() {
   if (isInitialised) {
     LanguageBarrierLog("LanguageBarrierInit() called twice...");

--- a/LanguageBarrier/LanguageBarrier.h
+++ b/LanguageBarrier/LanguageBarrier.h
@@ -12,6 +12,7 @@
 #include "MinHook.h"
 
 namespace lb {
+size_t alignCeil(size_t val, size_t align);
 void LanguageBarrierInit();
 void LanguageBarrierLog(const std::string &text);
 bool scanCreateEnableHook(char *category, char *name, uintptr_t *ppTarget,

--- a/LanguageBarrier/LanguageBarrier.vcxproj
+++ b/LanguageBarrier/LanguageBarrier.vcxproj
@@ -66,7 +66,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dbghelp.lib;shlwapi.lib;Alg.lib;Simd.lib;VSFilter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dbghelp.lib;shlwapi.lib;VSFilter.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
       <Command>
@@ -108,7 +108,7 @@ endlocal</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dbghelp.lib;shlwapi.lib;Alg.lib;Simd.lib;VSFilter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dbghelp.lib;shlwapi.lib;VSFilter.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
       <Command>


### PR DESCRIPTION
Remove Simd library (simd.sf.net) dependency from master (SGHD) branch. Backported from multi-game.

We don't use anything substantial in here and this lets me get that thing off my disk. (To anyone watching, sorry, nothing to see here.)